### PR TITLE
Various fixes concerning normalization

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
 
 setup(name='dual_quaternions_ros',
-      version='0.2.2',
+      version='0.2.3',
       description='Dual quaternion implementation for use with ROS',
       long_description=readme(),
       url='http://github.com/Achllle/dual_quaternions_ros',


### PR DESCRIPTION
Normalization wasn't set up right which I ran into after finding an odd case in the tests where two dual quaternions were different in their dual part but the homogeneous transformation matrix representation was exactly the same. This was due to unnormalized dual quaternions which were provided in the tests.
This fixes that and clarifies.

Additional tests added.