### PR TITLE
From screw parameters to dual quaternions and back

### DIFF
--- a/dual_quaternions_ros/dual_quaternions.py
+++ b/dual_quaternions_ros/dual_quaternions.py
@@ -371,7 +371,6 @@ class DualQuaternion(object):
         """
         # start by extracting theta and l directly from the real part of the dual quaternion
         theta = self.q_r.angle()
-        # TODO deal with theta ~= pi
         theta_close_to_zero = np.isclose(theta, 0)
         t = np.array(self.translation())
 
@@ -382,7 +381,6 @@ class DualQuaternion(object):
             d = np.dot(t, l)
 
             # m is a bit more complicated. Derivation see K. Daniliidis, Hand-eye calibration using Dual Quaternions
-            #TODO this doesn't seem to yield correct results?! Only works in subset of cases.
             m = 0.5 * (np.cross(t, l) + np.cross(l, np.cross(t, l) / np.tan(theta / 2)))
         else:
             # l points along the translation axis

--- a/dual_quaternions_ros/dual_quaternions.py
+++ b/dual_quaternions_ros/dual_quaternions.py
@@ -359,8 +359,8 @@ class DualQuaternion(object):
     def screw(self):
         """
         Get the screw parameters for this dual quaternion.
-        Chasles' theorem (screw theorem) states that any rigid displacement is equivalent to a rotation about some
-        line and a translation in the direction of the line. This line does not go through the origin!
+        Chasles' theorem (Mozzi, screw theorem) states that any rigid displacement is equivalent to a rotation about
+        some line and a translation in the direction of the line. This line does not go through the origin!
         This function returns the Plucker coordinates for the screw axis (l, m) as well as the amount of rotation
         and translation, theta and d.
         If the dual quaternion represents a pure translation, theta will be zero and the screw moment m will be at
@@ -398,11 +398,10 @@ class DualQuaternion(object):
         """
         Create a DualQuaternion from screw parameters
 
-        :param l:
-        :param m:
-        :param theta:
-        :param d:
-        :return:
+        :param l: unit vector defining screw axis direction
+        :param m: screw axis moment, perpendicular to l and through the origin
+        :param theta: screw angle; rotation around the screw axis
+        :param d: displacement along the screw axis
         """
         theta = float(theta)
         d = float(d)

--- a/dual_quaternions_ros/dual_quaternions.py
+++ b/dual_quaternions_ros/dual_quaternions.py
@@ -382,6 +382,7 @@ class DualQuaternion(object):
             d = np.dot(t, l)
 
             # m is a bit more complicated. Derivation see K. Daniliidis, Hand-eye calibration using Dual Quaternions
+            #TODO this doesn't seem to yield correct results?! Only works in subset of cases.
             m = 0.5 * (np.cross(t, l) + np.cross(l, np.cross(t, l) / np.tan(theta / 2)))
         else:
             # l points along the translation axis
@@ -405,6 +406,8 @@ class DualQuaternion(object):
         :param d:
         :return:
         """
+        theta = float(theta)
+        d = float(d)
         q_r = np.quaternion(np.cos(theta/2), 0, 0, 0)
         q_r.vec = np.sin(theta/2) * l
         q_d = np.quaternion(-d/2 * np.sin(theta/2), 0, 0, 0)

--- a/dual_quaternions_ros/dual_quaternions.py
+++ b/dual_quaternions_ros/dual_quaternions.py
@@ -403,6 +403,11 @@ class DualQuaternion(object):
         :param theta: screw angle; rotation around the screw axis
         :param d: displacement along the screw axis
         """
+        l = np.array(l)
+        m = np.array(m)
+        if not np.isclose(np.linalg.norm(l), 1):
+            raise AttributeError("Expected l to be a unit vector, received {} with norm {} instead"
+                                 .format(l, np.linalg.norm(l)))
         theta = float(theta)
         d = float(d)
         q_r = np.quaternion(np.cos(theta/2), 0, 0, 0)

--- a/dual_quaternions_ros/tests/test_dual_quaternions.py
+++ b/dual_quaternions_ros/tests/test_dual_quaternions.py
@@ -278,6 +278,21 @@ class TestDualQuaternion(TestCase):
         self.assertAlmostEqual(d, displacement_z)  # only displacement along z should exist here
         self.assertAlmostEqual(theta, theta2)  # the angles should be the same
 
+    def test_from_screw(self):
+        l = np.array([0, 0, 1])
+        m = np.cross(np.array([0, 1, 0]), l)
+        theta = np.pi/4
+        d = 1
+        dq = DualQuaternion.from_screw(l, m, theta, d)
+        lr, mr, thetar, dr = dq.screw()
+        try:
+            np.testing.assert_array_almost_equal(l, lr, decimal=3)
+            np.testing.assert_array_almost_equal(m, mr, decimal=3)
+        except AssertionError as e:
+            self.fail(e)
+        self.assertAlmostEqual(theta, thetar)
+        self.assertAlmostEqual(d, dr)
+
     def test_saving_loading(self):
         # get the cwd so we can create a couple test files that we'll remove later
         dir = os.getcwd()

--- a/dual_quaternions_ros/tests/test_dual_quaternions.py
+++ b/dual_quaternions_ros/tests/test_dual_quaternions.py
@@ -262,8 +262,8 @@ class TestDualQuaternion(TestCase):
         # along -x. Rotate around z axis so that the coordinate system stays in the plane. Translate along z-axis
         theta2 = np.pi/4
         dq_rot2 = DualQuaternion.from_dq_array([np.cos(theta2 / 2), 0, 0, np.sin(theta2 / 2), 0, 0, 0, 0])
-        dist_axis = 5
-        displacement_z = 3
+        dist_axis = 5.
+        displacement_z = 3.
         dq_trans = DualQuaternion.from_translation_vector([-dist_axis, dist_axis, displacement_z])
         dq_comb = dq_trans * dq_rot2
         l, m, theta, d = dq_comb.screw()
@@ -271,7 +271,6 @@ class TestDualQuaternion(TestCase):
             # the direction of the axis should align with the z axis of the origin
             np.testing.assert_array_almost_equal(l, np.array([0, 0, 1]), decimal=3)
             # m = p x l with p any point on the line
-            # self.assertAlmostEqual(np.sum(m), dist_axis)
             np.testing.assert_array_almost_equal(np.cross(np.array([[-dist_axis, 0, 0]]), l).flatten(), m)
         except AssertionError as e:
             self.fail(e)
@@ -282,7 +281,7 @@ class TestDualQuaternion(TestCase):
         l = np.array([0, 0, 1])
         m = np.cross(np.array([0, 1, 0]), l)
         theta = np.pi/4
-        d = 1
+        d = 3.
         dq = DualQuaternion.from_screw(l, m, theta, d)
         lr, mr, thetar, dr = dq.screw()
         try:

--- a/dual_quaternions_ros/tests/test_dual_quaternions.py
+++ b/dual_quaternions_ros/tests/test_dual_quaternions.py
@@ -260,7 +260,7 @@ class TestDualQuaternion(TestCase):
 
         # test simple rotation and translation: rotate in the plane of a coordinate system with the screw axis offset
         # along -x. Rotate around z axis so that the coordinate system stays in the plane. Translate along z-axis
-        theta2 = np.pi/2
+        theta2 = np.pi/4
         dq_rot2 = DualQuaternion.from_dq_array([np.cos(theta2 / 2), 0, 0, np.sin(theta2 / 2), 0, 0, 0, 0])
         dist_axis = 5
         displacement_z = 3

--- a/dual_quaternions_ros/tests/test_dual_quaternions.py
+++ b/dual_quaternions_ros/tests/test_dual_quaternions.py
@@ -259,38 +259,66 @@ class TestDualQuaternion(TestCase):
         self.assertAlmostEqual(theta, theta1)
 
         # test simple rotation and translation: rotate in the plane of a coordinate system with the screw axis offset
-        # along -x. Rotate around z axis so that the coordinate system stays in the plane. Translate along z-axis
-        theta2 = np.pi/4
+        # along +y. Rotate around z axis so that the coordinate system stays in the plane. Translate along z-axis
+        theta2 = np.pi/2
         dq_rot2 = DualQuaternion.from_dq_array([np.cos(theta2 / 2), 0, 0, np.sin(theta2 / 2), 0, 0, 0, 0])
         dist_axis = 5.
         displacement_z = 3.
-        dq_trans = DualQuaternion.from_translation_vector([-dist_axis, dist_axis, displacement_z])
+        dq_trans = DualQuaternion.from_translation_vector([dist_axis*np.sin(theta2), dist_axis*(1.-np.cos(theta2)),
+                                                           displacement_z])
         dq_comb = dq_trans * dq_rot2
         l, m, theta, d = dq_comb.screw()
         try:
             # the direction of the axis should align with the z axis of the origin
             np.testing.assert_array_almost_equal(l, np.array([0, 0, 1]), decimal=3)
             # m = p x l with p any point on the line
-            np.testing.assert_array_almost_equal(np.cross(np.array([[-dist_axis, 0, 0]]), l).flatten(), m)
+            np.testing.assert_array_almost_equal(np.cross(np.array([[0, dist_axis, 0]]), l).flatten(), m)
         except AssertionError as e:
             self.fail(e)
         self.assertAlmostEqual(d, displacement_z)  # only displacement along z should exist here
         self.assertAlmostEqual(theta, theta2)  # the angles should be the same
 
     def test_from_screw(self):
+        # construct an axis along the positive z-axis
         l = np.array([0, 0, 1])
-        m = np.cross(np.array([0, 1, 0]), l)
-        theta = np.pi/4
+        # pick a point on the axis that defines it's location
+        p = np.array([-1, 0, 0])
+        # moment vector
+        m = np.cross(p, l)
+        theta = np.pi/2
         d = 3.
+        # this corresponds to a rotation around the axis parallel with the origin's z-axis through the point p
+        # the resulting transformation should move the origin to a DQ with elements:
+        desired_dq_rot = DualQuaternion.from_quat_pose_array([np.cos(theta/2), 0, 0, np.sin(theta/2), 0, 0, 0])
+        desired_dq_trans = DualQuaternion.from_translation_vector([-1, 1, d])
+        desired_dq = desired_dq_trans * desired_dq_rot
         dq = DualQuaternion.from_screw(l, m, theta, d)
+        self.assertEqual(dq, desired_dq)
+
+    def test_from_screw_and_back(self):
+        # start with a random valid dual quaternion
+        dq = DualQuaternion.from_quat_pose_array([0.5, 0.3, 0.1, 0.4, 2, 5, -2])
         lr, mr, thetar, dr = dq.screw()
+        dq_reconstructed = DualQuaternion.from_screw(lr, mr, thetar, dr)
+        self.assertEqual(dq, dq_reconstructed)
+
+        # start with some screw parameters
+        l1 = np.array([0.4, 0.2, 0.5])
+        l1 /= np.linalg.norm(l1)  # make sure l1 is normalized
+        # pick some point away from the origin
+        p1 = np.array([2.3, 0.9, 1.1])
+        m1 = np.cross(p1, l1)
+        d1 = 4.32
+        theta1 = 1.94
+        dq1 = DualQuaternion.from_screw(l1, m1, theta1, d1)
+        l2, m2, theta2, d2 = dq1.screw()
         try:
-            np.testing.assert_array_almost_equal(l, lr, decimal=3)
-            np.testing.assert_array_almost_equal(m, mr, decimal=3)
+            np.testing.assert_array_almost_equal(l1, l2, decimal=3)
+            np.testing.assert_array_almost_equal(l1, l2, decimal=3)
         except AssertionError as e:
             self.fail(e)
-        self.assertAlmostEqual(theta, thetar)
-        self.assertAlmostEqual(d, dr)
+        self.assertAlmostEqual(theta1, theta2)
+        self.assertAlmostEqual(d1, d2)
 
     def test_saving_loading(self):
         # get the cwd so we can create a couple test files that we'll remove later


### PR DESCRIPTION
close #33 
see also #8 
Probably not going to use screw parameters to do interpolation as it is quite simple to do so using dual quaternions. Might want to add the analogy or cite good references