### PR TITLE
Check tests results in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ install:
   - cd ~/catkin_ws && catkin_make
 # command to run tests
 script:
-  - catkin_make run_tests
+  - catkin_make run_tests && catkin_test_results


### PR DESCRIPTION
Travis would show errors with `catkin_make_run_tests` but they wouldn't actually cause Travis to report a failed test. This fixes that. Tested with a failed test on #50 