### PR TITLE
Remove catkin dependencies from CmakeLists.txt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package dual_quaternions_ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Remove find_package (build) dependencies in dq_ros: not needed during build, just at runtime
+* Contributors: Achille
+
 0.1.3 (2020-05-29)
 ------------------
 * Merge pull request #53 from Achllle/ros_only

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package dual_quaternions_ros
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.1.4 (2020-07-07)
+------------------
 * Remove find_package (build) dependencies in dq_ros: not needed during build, just at runtime
 * Contributors: Achille
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(dual_quaternions_ros)
 
-find_package(catkin REQUIRED COMPONENTS
-  geometry_msgs
-  dual_quaternions
-)
+find_package(catkin REQUIRED)
 
 catkin_package()
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>dual_quaternions_ros</name>
-  <version>0.1.3</version>
+  <version>0.1.4</version>
   <description>ROS msgs from and to dual quaternions</description>
 
   <maintainer email="achille.verheye@gmail.com">achille</maintainer>

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ def readme():
         return f.read()
 
 setup(name='dual_quaternions_ros',
-      version='0.1.3',
+      version='0.1.4',
       description='Dual quaternion ROS converter',
       long_description=readme(),
       url='http://github.com/Achllle/dual_quaternions_ros/tree/master/dual_quaternions_ros',


### PR DESCRIPTION
Fixes build errors in ROS' Jenkins + aren't necessary because dependencies aren't required for build, only at runtime